### PR TITLE
Adds fullWidth prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ export default class RelativePortal extends React.Component {
   static propTypes = {
     right: PropTypes.number, // set right offset from current position. If undefined portal positons from left
     left: PropTypes.number, // set left offset from current position. If `right` prop is set, `left` ignores
+    fullWidth: PropTypes.bool, // enables you to set both left and right portal positions
     top: PropTypes.number, // set top offset from current position
     children: PropTypes.any.isRequired, // portal content
     onOutClick: PropTypes.func, // called when user click outside portal element

--- a/src/RelativePortal.js
+++ b/src/RelativePortal.js
@@ -29,6 +29,7 @@ export default class RelativePortal extends React.Component {
     top: PropTypes.number,
     children: PropTypes.any,
     onOutClick: PropTypes.func,
+    fullWidth: PropTypes.bool,
     component: PropTypes.string.isRequired,
   };
 
@@ -70,9 +71,14 @@ export default class RelativePortal extends React.Component {
   }
 
   render() {
-    const { component: Comp, top, left, right, ...props } = this.props;
-    const horizontalPosition = right !== undefined ? { right: this.state.right + right }
-                                                 : { left: this.state.left + left };
+    const { component: Comp, top, left, right, fullWidth, ...props } = this.props;
+
+    const fromLeftOrRight = right !== undefined ?
+      { right: this.state.right + right } :
+      { left: this.state.left + left };
+
+    const horizontalPosition = fullWidth ?
+      { right: this.state.right + right, left: this.state.left + left } : fromLeftOrRight;
 
     return (
       <Comp

--- a/src/RelativePortal.js
+++ b/src/RelativePortal.js
@@ -71,7 +71,7 @@ export default class RelativePortal extends React.Component {
 
   render() {
     const { component: Comp, top, left, right, ...props } = this.props;
-    const verticalPosition = right !== undefined ? { right: this.state.right + right }
+    const horizontalPosition = right !== undefined ? { right: this.state.right + right }
                                                  : { left: this.state.left + left };
 
     return (
@@ -85,7 +85,7 @@ export default class RelativePortal extends React.Component {
             style={{
               position: 'absolute',
               top: this.state.top + top,
-              ...verticalPosition,
+              ...horizontalPosition,
             }}
           >
             {this.props.children}

--- a/src/RelativePortal.js
+++ b/src/RelativePortal.js
@@ -26,10 +26,10 @@ export default class RelativePortal extends React.Component {
   static propTypes = {
     right: PropTypes.number,
     left: PropTypes.number,
+    fullWidth: PropTypes.bool,
     top: PropTypes.number,
     children: PropTypes.any,
     onOutClick: PropTypes.func,
-    fullWidth: PropTypes.bool,
     component: PropTypes.string.isRequired,
   };
 


### PR DESCRIPTION
This PR adds a fullWidth prop, which then allows for both the left and the right prop to be set.

Why? In some cases, it's useful to do so -- for example when you want the dropdown to always be the full width of the parent.

