### PR TITLE
Use ReactDOM.unstable_renderSubtreeIntoContainer()

### DIFF
--- a/src/Portal.js
+++ b/src/Portal.js
@@ -29,7 +29,8 @@ export default class Portal extends React.Component {
   }
 
   componentWillUpdate({ onOutClick, ...props }) { // eslint-disable-line
-    this.element = ReactDOM.render(
+    this.element = ReactDOM.unstable_renderSubtreeIntoContainer(
+      this,
       <div {...props} />,
       this.node
     );


### PR DESCRIPTION
That preserves context and makes more libs compatible because of that.