### PR TITLE
docs(README): fix example onOutClick propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,26 @@ export default class DropdownLink extends React.Component {
       show: false,
     };
 
-    this.handleToggle = () => {
-      this.setState({ show: !this.state.show });
+    this._setShowAsyncTimer = null;
+
+    this._handleShow = () => {
+      this._setShowAsync(true);
     };
 
-    this.handleHide = () => {
-      this.setState({ show: false });
+    this._handleHide = () => {
+      this._setShowAsync(false);
     };
+  }
+  
+  componentWillUnmount() {
+    clearTimeout(this._setShowAsyncTimer);
+  }
+  
+  _setShowAsync(show) {
+    clearTimeout(this._setShowAsyncTimer);
+    this._setShowAsyncTimer = setTimeout(() => {
+      this.setState({ show: show });
+    }, 0);
   }
 
   render() {
@@ -32,14 +45,14 @@ export default class DropdownLink extends React.Component {
 
     return (
       <div>
-        <button onClick={this.handleToggle}>
+        <button onClick={show ? this._handleHide : this._handleShow}>
           Dropdown toggle
         </button>
         <RelativePortal
           component="div"
           left={0}
           top={10}
-          onOutClick={show ? this.handleHide : null}
+          onOutClick={show ? this._handleHide : null}
         >
           {show &&
             <div style={{ padding: 10, backgroundColor: '#FFF' }}>

--- a/README.md
+++ b/README.md
@@ -30,10 +30,19 @@ export default class DropdownLink extends React.Component {
   }
   
   componentWillUnmount() {
+    // Prevent the asynchronous `setState` call after unmount.
     clearTimeout(this._setShowAsyncTimer);
   }
   
+  /**
+   * Changes the dropdown show/hide state asynchronously.
+   *
+   * Need to change the dropdown state asynchronously,
+   * otherwise the dropdown gets immediately closed
+   * during the dropdown toggle's `onClick` which propagates to `onOutClick`.
+   */
   _setShowAsync(show) {
+    // Prevent multiple asynchronous `setState` calls, jsut the latest has to happen.
     clearTimeout(this._setShowAsyncTimer);
     this._setShowAsyncTimer = setTimeout(() => {
       this.setState({ show: show });

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export default class DropdownLink extends React.Component {
           component="div"
           left={0}
           top={10}
-          onOutClick={this.handleHide}
+          onOutClick={show ? this.handleHide : null}
         >
           {show &&
             <div style={{ padding: 10, backgroundColor: '#FFF' }}>


### PR DESCRIPTION
If `onOutClick` hides the dropdown when it's not open, the dropdown gets immediately hidden during handling the dropdown toggle click because of event propagation, so the dropdown never opens.
The demo page https://smartprogress.github.io/react-relative-portal/ has already had the correct code.