### PR TITLE
Defer initialization of dom event listener after document.body is loaded

### DIFF
--- a/src/RelativePortal.js
+++ b/src/RelativePortal.js
@@ -20,9 +20,17 @@ function getPageOffset() {
   }
 }
 
-if (canUseDOM) {
+function initDOMListener() {
   document.body.addEventListener('mousewheel', debounce(fireListeners, 100, true));
   window.addEventListener('resize', debounce(fireListeners, 50, true));
+}
+
+if (canUseDOM) {
+  if (document.body) {
+    initDOMListener();
+  } else {
+    document.addEventListener('DOMContentLoaded', initDOMListener);
+  }
 }
 
 let listenerIdCounter = 0;


### PR DESCRIPTION
Fix #10 with initialization error of document.body is undefined when the script is loaded before the DOM content initialization.