### PR TITLE
Move PropTypes to prop-types module

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "dependencies": {
     "debounce": "^1.0.0",
-    "exenv": "^1.2.1"
+    "exenv": "^1.2.1",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": ">=0.14.0",

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { canUseDOM } from 'exenv';
 

--- a/src/RelativePortal.js
+++ b/src/RelativePortal.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import debounce from 'debounce';
 import { canUseDOM } from 'exenv';
 import Portal from './Portal';


### PR DESCRIPTION
React 16 removes PropTypes in main React module. The `prop-types` module provides it.